### PR TITLE
Fix file not found

### DIFF
--- a/LibUISharp.sln
+++ b/LibUISharp.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrawTextDemo", "demos\DrawT
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HistogramDemo", "demos\HistogramDemo\HistogramDemo.csproj", "{0651053B-EA5F-4014-8001-32A7871F66C3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleWindowDemo", "demos\SimpleWindowDemo\SimpleWindowDemo.csproj", "{B929A697-638D-447C-B413-7E61F6B5B1F7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{0651053B-EA5F-4014-8001-32A7871F66C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0651053B-EA5F-4014-8001-32A7871F66C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0651053B-EA5F-4014-8001-32A7871F66C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B929A697-638D-447C-B413-7E61F6B5B1F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B929A697-638D-447C-B413-7E61F6B5B1F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B929A697-638D-447C-B413-7E61F6B5B1F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B929A697-638D-447C-B413-7E61F6B5B1F7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/demos/SimpleWindowDemo/Program.cs
+++ b/demos/SimpleWindowDemo/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using LibUISharp;
+
+namespace SimpleWindowDemo
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Application app = new Application();
+            Window w = new Window();
+
+            app.Run(w);
+        }
+    }
+}

--- a/demos/SimpleWindowDemo/SimpleWindowDemo.csproj
+++ b/demos/SimpleWindowDemo/SimpleWindowDemo.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\source\LibUISharp\LibUISharp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/source/LibUISharp/src/LibUISharp/Internal/LibuiLibrary.cs
+++ b/source/LibUISharp/src/LibUISharp/Internal/LibuiLibrary.cs
@@ -11,9 +11,20 @@ namespace LibUISharp.Internal
 
         private static class FunctionLoader
         {
-            private static readonly string[] WinNTLibNames = new[] { "libui.dll" };
-            private static readonly string[] LinuxLibNames = new[] { "libui.so", "libui.so.0" };
-            private static readonly string[] MacOSLibNames = new[] { "libui.dylib", "libui.A.dylib" };
+            private static readonly string[] WinNTLibNames = new[] 
+            {
+                @"runtimes\win7-x64\native\libui.dll"
+            };
+            private static readonly string[] LinuxLibNames = new[] 
+            {
+                @"runtimes\linux-x64\native\libui.so",
+                @"runtimes\linux-x64\native\libui.so.0"
+            };
+            private static readonly string[] MacOSLibNames = new[]
+            {
+                @"runtimes\osx-x64\native\libui.dylib",
+                @"runtimes\osx-x64\native\libui.A.dylib"
+            };
 
             private static NativeLibrary LibuiNativeLibrary
             {


### PR DESCRIPTION
Hi, I think I figured out the issue!  

Whenever LibUiSharp builds(or any project that references it), everything in the runtimes folder gets copied to the program's output directory.  This is what the /bin/debug folder looks like after compiling:

* Debug
    * ProgramName.dll
    * LibUiSharp.dll
    * runtimes
        * win7-x64
            * native
                * libui.dll
        * linux-x64
            * native
                * you get the idea

If we look at the code where you specify the path the the DLL, though, it looks like this:
`

            private static readonly string[] WinNTLibNames = new[] { "libui.dll" };

            private static readonly string[] LinuxLibNames = new[] { "libui.so", "libui.so.0" };

            private static readonly string[] MacOSLibNames = new[] { "libui.dylib", "libui.A.dylib" };
`

See the problem?  You're looking for "libui.dll" when you should be looking for "runtimes/win7-x64/native/libui.dll" instead.  Changing all of the file names to include the runtimes directory should fix the FileNotFoundException.  I'm preparing a pull request with the fix right now :)

Unfortunately, a different exception rears its head after fixing this one, but that's still progress.

This should close Issue 10.