### PR TITLE
Proper UI Threading

### DIFF
--- a/source/LibUISharp/src/LibUISharp/Application.cs
+++ b/source/LibUISharp/src/LibUISharp/Application.cs
@@ -11,7 +11,7 @@ namespace LibUISharp
     public sealed class Application : LibuiComponent
     {
         private static object _lock = new object();
-        private static bool created;
+        private static bool created = false;
         private static LibuiLibrary.uiInitOptions Options = new LibuiLibrary.uiInitOptions() { Size = UIntPtr.Zero };
         private int exitCode;
         private bool disposed;
@@ -106,12 +106,6 @@ namespace LibUISharp
         /// <inheritdoc />
         protected sealed override void InitializeComponent()
         {
-            if (PlatformHelper.IsWinNT)
-            {
-                IntPtr ptr = Kernel32Library.GetConsoleWindow();
-                User32Library.ShowWindow(ptr, 0); // 0 = SW_HIDE, 4 = SW_SHOWNOACTIVATE
-            }
-
             IntPtr errPtr = LibuiLibrary.uiInit(ref Options);
             string errStr = errPtr.ToStringEx();
 
@@ -120,6 +114,12 @@ namespace LibUISharp
                 Console.WriteLine(errStr);
                 LibuiLibrary.uiFreeInitError(errPtr);
                 throw new LibuiException(errStr);
+            }
+
+            if (PlatformHelper.IsWinNT)
+            {
+                IntPtr ptr = Kernel32Library.GetConsoleWindow();
+                User32Library.ShowWindow(ptr, 0); // 0 = SW_HIDE, 4 = SW_SHOWNOACTIVATE
             }
         }
 

--- a/source/LibUISharp/src/LibUISharp/Application.cs
+++ b/source/LibUISharp/src/LibUISharp/Application.cs
@@ -1,6 +1,7 @@
 ﻿using LibUISharp.Internal;
 using System;
 using System.ComponentModel;
+using System.Text;
 
 namespace LibUISharp
 {
@@ -20,6 +21,7 @@ namespace LibUISharp
         /// </summary>
         public Application()
         {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             lock (_lock)
             {
                 if (created)


### PR DESCRIPTION
This pull request is far from finished, since I cannot find a reason that #15 is happening, but the only reason I can find online is that something is initializing `libui.*` more than once, and it is recieving a failure code since it can't be initialized twice (but I honestly have no clue).

Adding `[STAThread]` or `[MTAThread]` attributes to either demo projects `Main()` method doesn't help solve the issue ATM.

If anyone has any ideas, feel free to comment or add a PR towards the [`app-threading`](https://github.com/tom-corwin/LibUISharp/tree/app-threading) branch.