### PR TITLE
Suggestion to avoid null strings for default values to avoid crashes on MacOS

### DIFF
--- a/source/LibUISharp/src/LibUISharp/Window.cs
+++ b/source/LibUISharp/src/LibUISharp/Window.cs
@@ -218,8 +218,8 @@ namespace LibUISharp
             if (w == null)
                 w = Application.MainWindow;
 
-            IntPtr titlePtr = title.ToLibuiString();
-            IntPtr descriptionPtr = description.ToLibuiString();
+            IntPtr titlePtr = (title ?? string.Empty).ToLibuiString();
+            IntPtr descriptionPtr = (description ?? string.Empty).ToLibuiString();
             if (isError)
                 LibuiLibrary.uiMsgBoxError(w.Handle.DangerousGetHandle(), titlePtr, descriptionPtr);
             else


### PR DESCRIPTION
A minor guard against default null string values (and corresponding 0 value IntPtr) for common use cases. Since some parameters like "description" is optional on the method, it should not lead to a crash but be substituted with an empty string instead.
A global fix may be possible to patch within the ToLibuiString, however it will likely lead to side effects, as there may be times where string == null is indeed needed to equate to IntPtr == 0. 